### PR TITLE
Added MainClass to manifest, simple build/run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@ DroidQuest
 
 A Java recreation of the classic game Robot Odyssey I
 
+Build with:
+
+   mvn install
+
+Run with:
+
+   java -jar target/dq-1.1-SNAPSHOT.jar
 
 Copyright (c) 2000 Thomas Foote
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,33 @@ Run with:
 
    java -jar target/dq-1.1-SNAPSHOT.jar
 
+Controls:
+
+    / - help
+    arrows - normal movement
+    control + arrows - fine-grained movement [OS X: command + arrows]
+    space - pickup/drop
+    C - game cursor
+    H - hot cursor
+    S - solder pen
+    R - toggle radio
+    P - paintbrush
+    T - toolbox
+    [, ] - rotate
+    F - flip
+    L - load small chip
+    E - enter room
+    X - exit room
+
+    Cheat/debug:
+
+    shift + arrows - move rooms
+    M - dump memory usage
+
+Note: On OS X, control + arrow-keys are bound to Apple's "Mission Control".  I switched to the 'shortcut' modifier which is control on windows and command on OS X.  Alternatively, you can disable
+built in OS X shortcuts via System Preferences -> Keyboard -> Shorcuts.
+
+
 Copyright (c) 2000 Thomas Foote
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Run with:
 
 Controls:
 
-    / - help
+    / - contextual help
     arrows - normal movement
     control + arrows - fine-grained movement [OS X: command + arrows]
     space - pickup/drop
@@ -23,11 +23,11 @@ Controls:
     R - toggle radio
     P - paintbrush
     T - toolbox
-    [, ] - rotate
+    [, ] - rotate device
     F - flip
     L - load small chip
-    E - enter room
-    X - exit room
+    E - enter robot
+    X - exit robot
 
     Cheat/debug:
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,23 @@
 
     <build>
         <sourceDirectory>src</sourceDirectory>
+        <plugins>
+            <plugin>
+              <!-- Build an executable JAR -->
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-jar-plugin</artifactId>
+              <version>2.4</version>
+              <configuration>
+                <archive>
+                  <manifest>
+                    <addClasspath>true</addClasspath>
+                    <classpathPrefix>lib/</classpathPrefix>
+                    <mainClass>com.droidquest.DQ</mainClass>
+                  </manifest>
+                </archive>
+              </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencies>

--- a/src/com/droidquest/avatars/Player.java
+++ b/src/com/droidquest/avatars/Player.java
@@ -15,7 +15,7 @@ import java.awt.event.KeyEvent;
 public class Player extends Item implements Avatar {
 
     private int keyRepeatRate = 5;
-
+    private int shortcut_modifier = Toolkit.getDefaultToolkit ().getMenuShortcutKeyMask();
 
     protected boolean handleSaveSmallChip() {
         return false;
@@ -362,16 +362,16 @@ public class Player extends Item implements Avatar {
         else if (e.getKeyCode() == KeyEvent.VK_SLASH && handleHelp()) {
             return false;
         }
-        else if (e.getKeyCode() == KeyEvent.VK_RIGHT && handleMoveRight(e.isShiftDown(), e.isControlDown())) {
+        else if (e.getKeyCode() == KeyEvent.VK_RIGHT && handleMoveRight(e.isShiftDown(), (e.getModifiers() & shortcut_modifier) > 0)) {
             return true;
         }
-        else if (e.getKeyCode() == KeyEvent.VK_LEFT && handleMoveLeft(e.isShiftDown(), e.isControlDown())) {
+        else if (e.getKeyCode() == KeyEvent.VK_LEFT && handleMoveLeft(e.isShiftDown(), (e.getModifiers() & shortcut_modifier) > 0)) {
             return true;
         }
-        else if (e.getKeyCode() == KeyEvent.VK_UP && handleMoveUp(e.isShiftDown(), e.isControlDown())) {
+        else if (e.getKeyCode() == KeyEvent.VK_UP && handleMoveUp(e.isShiftDown(), (e.getModifiers() & shortcut_modifier) > 0)) {
             return true;
         }
-        else if (e.getKeyCode() == KeyEvent.VK_DOWN && handleMoveDown(e.isShiftDown(), e.isControlDown())) {
+        else if (e.getKeyCode() == KeyEvent.VK_DOWN && handleMoveDown(e.isShiftDown(), (e.getModifiers() & shortcut_modifier) > 0)) {
             return true;
         }
         else if (e.getKeyCode() == KeyEvent.VK_SPACE && handlePickupDrop()) {
@@ -455,22 +455,22 @@ public class Player extends Item implements Avatar {
 
     public boolean KeyDown(KeyEvent e) {
         if (e.getKeyCode() == KeyEvent.VK_RIGHT) {
-            if (handleRepeatRight(e.isControlDown())) {
+            if (handleRepeatRight((e.getModifiers() & shortcut_modifier) > 0)) {
                 return true;
             }
         }
         else if (e.getKeyCode() == KeyEvent.VK_LEFT) {
-            if (handleRepeatLeft(e.isControlDown())) {
+            if (handleRepeatLeft((e.getModifiers() & shortcut_modifier) > 0)) {
                 return true;
             }
         }
         else if (e.getKeyCode() == KeyEvent.VK_UP) {
-            if (handleRepeatUp(e.isControlDown())) {
+            if (handleRepeatUp((e.getModifiers() & shortcut_modifier) > 0)) {
                 return true;
             }
         }
         else if (e.getKeyCode() == KeyEvent.VK_DOWN) {
-            if (handleRepeatDown(e.isControlDown())) {
+            if (handleRepeatDown((e.getModifiers() & shortcut_modifier) > 0)) {
                 return true;
             }
         }

--- a/src/com/droidquest/avatars/Remote.java
+++ b/src/com/droidquest/avatars/Remote.java
@@ -8,6 +8,8 @@ import java.awt.event.KeyEvent;
 import java.awt.image.BufferedImage;
 
 public class Remote extends Item implements Avatar {
+    private int shortcut_modifier = Toolkit.getDefaultToolkit ().getMenuShortcutKeyMask();
+
     public Remote() {
         width = 4;
         height = 20;
@@ -98,28 +100,28 @@ public class Remote extends Item implements Avatar {
         }
         else if (e.getKeyCode() == KeyEvent.VK_RIGHT) {
             if (carriedBy == null) {
-                moveRight(e.isControlDown());
+                moveRight((e.getModifiers() & shortcut_modifier) > 0);
             }
             repeating = 0;
             return true;
         }
         else if (e.getKeyCode() == KeyEvent.VK_LEFT) {
             if (carriedBy == null) {
-                moveLeft(e.isControlDown());
+                moveLeft((e.getModifiers() & shortcut_modifier) > 0);
             }
             repeating = 0;
             return true;
         }
         else if (e.getKeyCode() == KeyEvent.VK_UP) {
             if (carriedBy == null) {
-                moveUp(e.isControlDown());
+                moveUp((e.getModifiers() & shortcut_modifier) > 0);
             }
             repeating = 0;
             return true;
         }
         else if (e.getKeyCode() == KeyEvent.VK_DOWN) {
             if (carriedBy == null) {
-                moveDown(e.isControlDown());
+                moveDown((e.getModifiers() & shortcut_modifier) > 0);
             }
             repeating = 0;
             return true;
@@ -134,7 +136,7 @@ public class Remote extends Item implements Avatar {
         if (e.getKeyCode() == KeyEvent.VK_RIGHT) {
             repeating++;
             if (repeating > 10) {
-                moveRight(e.isControlDown());
+                moveRight((e.getModifiers() & shortcut_modifier) > 0);
                 return true;
             }
             return false;
@@ -142,7 +144,7 @@ public class Remote extends Item implements Avatar {
         else if (e.getKeyCode() == KeyEvent.VK_LEFT) {
             repeating++;
             if (repeating > 10) {
-                moveLeft(e.isControlDown());
+                moveLeft((e.getModifiers() & shortcut_modifier) > 0);
                 return true;
             }
             return false;
@@ -150,7 +152,7 @@ public class Remote extends Item implements Avatar {
         else if (e.getKeyCode() == KeyEvent.VK_UP) {
             repeating++;
             if (repeating > 10) {
-                moveUp(e.isControlDown());
+                moveUp((e.getModifiers() & shortcut_modifier) > 0);
                 return true;
             }
             return false;
@@ -158,7 +160,7 @@ public class Remote extends Item implements Avatar {
         else if (e.getKeyCode() == KeyEvent.VK_DOWN) {
             repeating++;
             if (repeating > 10) {
-                moveDown(e.isControlDown());
+                moveDown((e.getModifiers() & shortcut_modifier) > 0);
                 return true;
             }
             return false;

--- a/src/com/droidquest/avatars/SolderingPen.java
+++ b/src/com/droidquest/avatars/SolderingPen.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 public class SolderingPen extends Device implements Avatar {
     private boolean hot;
     private Port currentPort = null; // Port that Soldering pen is currently over
+    private int shortcut_modifier = Toolkit.getDefaultToolkit ().getMenuShortcutKeyMask();
 
     public SolderingPen() {
         width = 22;
@@ -313,28 +314,28 @@ public class SolderingPen extends Device implements Avatar {
         }
         else if (e.getKeyCode() == KeyEvent.VK_RIGHT) {
             if (carriedBy == null) {
-                moveRight(e.isControlDown());
+                moveRight((e.getModifiers() & shortcut_modifier) > 0);
             }
             repeating = 0;
             return true;
         }
         else if (e.getKeyCode() == KeyEvent.VK_LEFT) {
             if (carriedBy == null) {
-                moveLeft(e.isControlDown());
+                moveLeft((e.getModifiers() & shortcut_modifier) > 0);
             }
             repeating = 0;
             return true;
         }
         else if (e.getKeyCode() == KeyEvent.VK_UP) {
             if (carriedBy == null) {
-                moveUp(e.isControlDown());
+                moveUp((e.getModifiers() & shortcut_modifier) > 0);
             }
             repeating = 0;
             return true;
         }
         else if (e.getKeyCode() == KeyEvent.VK_DOWN) {
             if (carriedBy == null) {
-                moveDown(e.isControlDown());
+                moveDown((e.getModifiers() & shortcut_modifier) > 0);
             }
             repeating = 0;
             return true;
@@ -358,7 +359,7 @@ public class SolderingPen extends Device implements Avatar {
         if (e.getKeyCode() == KeyEvent.VK_RIGHT) {
             repeating++;
             if (repeating > 10) {
-                moveRight(e.isControlDown());
+                moveRight((e.getModifiers() & shortcut_modifier) > 0);
                 return true;
             }
             return false;
@@ -366,7 +367,7 @@ public class SolderingPen extends Device implements Avatar {
         else if (e.getKeyCode() == KeyEvent.VK_LEFT) {
             repeating++;
             if (repeating > 10) {
-                moveLeft(e.isControlDown());
+                moveLeft((e.getModifiers() & shortcut_modifier) > 0);
                 return true;
             }
             return false;
@@ -374,7 +375,7 @@ public class SolderingPen extends Device implements Avatar {
         else if (e.getKeyCode() == KeyEvent.VK_UP) {
             repeating++;
             if (repeating > 10) {
-                moveUp(e.isControlDown());
+                moveUp((e.getModifiers() & shortcut_modifier) > 0);
                 return true;
             }
             return false;
@@ -382,7 +383,7 @@ public class SolderingPen extends Device implements Avatar {
         else if (e.getKeyCode() == KeyEvent.VK_DOWN) {
             repeating++;
             if (repeating > 10) {
-                moveDown(e.isControlDown());
+                moveDown((e.getModifiers() & shortcut_modifier) > 0);
                 return true;
             }
             return false;


### PR DESCRIPTION
Fooling around programming some microcontrollers got me thinking about Robot Odyssey again after many years, and awesome to discover this reimplementation.

Couple of trivial changes to make it a little easier for java noob like me to build and run:

added MainClass to manifest so you can run jar easily
use portable shortcut modifier for arrows instead of just control, which conflicts with OS X builtin shortcuts (so now command-arrows on mac, control-arrows on windows)
added some instructions for build, run, and keyboard usage.
